### PR TITLE
Fix "Warning: Cannot modify header information..."

### DIFF
--- a/Includes/wc-2c2p-setting.php
+++ b/Includes/wc-2c2p-setting.php
@@ -1,4 +1,4 @@
- <?php
+<?php
 
 return array(    
     'enabled' => array(


### PR DESCRIPTION
Warning: Cannot modify header information - headers already sent by (output started at /home/username/public_html/wp-content/plugins/2c2p-redirect-api-for-woocommerce/Includes/wc-2c2p-setting.php:1) in /home/username/public_html/wp-includes/pluggable.php on line 1296